### PR TITLE
Use Dial instead of DialUDP and ResolveUDPAddr

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -159,6 +159,7 @@ func (g *Gelf) TestForForbiddenValues(gmap map[string]interface{}) error {
 func (g *Gelf) Send(b []byte) {
 	var addr = g.Config.GraylogHostname + ":" + strconv.Itoa(g.Config.GraylogPort)
 	conn, err := net.Dial("udp", addr)
+	defer conn.Close()
 	if err != nil {
 		log.Printf("Uh oh! %s", err)
 		return

--- a/gelf.go
+++ b/gelf.go
@@ -158,12 +158,7 @@ func (g *Gelf) TestForForbiddenValues(gmap map[string]interface{}) error {
 
 func (g *Gelf) Send(b []byte) {
 	var addr = g.Config.GraylogHostname + ":" + strconv.Itoa(g.Config.GraylogPort)
-	udpAddr, err := net.ResolveUDPAddr("udp", addr)
-	if err != nil {
-		log.Printf("Uh oh! %s", err)
-		return
-	}
-	conn, err := net.DialUDP("udp", nil, udpAddr)
+	conn, err := net.Dial("udp", addr)
 	if err != nil {
 		log.Printf("Uh oh! %s", err)
 		return


### PR DESCRIPTION
The motivation behind this is to support IPv6 hosts as DialUDP currently gives preference to IPv4 (might be fixed in 1.14): https://github.com/golang/go/issues/28666

Dial must be a sensible choice I believe as it takes off the overhead of DNS lookup and also prioritization of IPv4 and IPv6 which is automatically performed (v6 > v4).

